### PR TITLE
Support generic structs in derive(Niche)

### DIFF
--- a/controlled-option-macros/src/lib.rs
+++ b/controlled-option-macros/src/lib.rs
@@ -10,10 +10,13 @@ extern crate proc_macro;
 use proc_macro::TokenStream;
 use quote::quote;
 use syn::parse_macro_input;
+use syn::parse_quote;
 use syn::Field;
 use syn::Fields;
 use syn::Item;
 use syn::Member;
+use syn::Type;
+use syn::WhereClause;
 
 fn field_is_niche(field: &&Field) -> bool {
     for attr in &field.attrs {
@@ -24,49 +27,79 @@ fn field_is_niche(field: &&Field) -> bool {
     false
 }
 
+fn merge_where_clauses(lhs: Option<WhereClause>, rhs: WhereClause) -> WhereClause {
+    match lhs {
+        Some(mut lhs) => {
+            lhs.predicates.extend(rhs.predicates);
+            lhs
+        }
+        None => rhs,
+    }
+}
+
 #[proc_macro_derive(Niche, attributes(niche))]
 pub fn derive_decode(input: TokenStream) -> TokenStream {
     let item = parse_macro_input!(input as Item);
     match &item {
         Item::Struct(item) => {
             let ty_name = &item.ident;
+            let ty_generics = &item.generics;
+            let ty_where_clause = item.generics.where_clause.as_ref().cloned();
 
             // Find the field that is marked #[niche].  In a regular struct, extract its name; in a
             // tuple struct, extract its index.  In both cases, that can be converted into a
             // `Member`, which is the type needed down below in the field access expression.
-            let niche_field_name: Option<Member> = match &item.fields {
-                Fields::Named(fields) => fields
-                    .named
-                    .iter()
-                    .find(field_is_niche)
-                    .and_then(|field| field.ident.as_ref())
-                    .cloned()
-                    .map(Member::from),
-                Fields::Unnamed(fields) => fields
-                    .unnamed
-                    .iter()
-                    .enumerate()
-                    .find(|(_, field)| field_is_niche(field))
-                    .map(|(idx, _)| idx.into()),
+            let niche_field_name: Member;
+            let niche_field_type: &Type;
+            match &item.fields {
+                Fields::Named(fields) => {
+                    let niche_field = match fields.named.iter().find(field_is_niche) {
+                        Some(field) if field.ident.is_some() => field,
+                        _ => {
+                            let msg = "#[derive(Niche)] requires a field marked #[niche]";
+                            return syn::parse::Error::new_spanned(item, msg)
+                                .to_compile_error()
+                                .into();
+                        }
+                    };
+                    niche_field_name = niche_field.ident.as_ref().unwrap().clone().into();
+                    niche_field_type = &niche_field.ty;
+                }
+                Fields::Unnamed(fields) => {
+                    let (idx, niche_field) = match fields
+                        .unnamed
+                        .iter()
+                        .enumerate()
+                        .find(|(_, field)| field_is_niche(field))
+                    {
+                        Some((idx, field)) => (idx, field),
+                        None => {
+                            let msg = "#[derive(Niche)] requires a field marked #[niche]";
+                            return syn::parse::Error::new_spanned(item, msg)
+                                .to_compile_error()
+                                .into();
+                        }
+                    };
+                    niche_field_name = idx.into();
+                    niche_field_type = &niche_field.ty;
+                }
                 Fields::Unit => {
                     let msg = "#[derive(Niche)] cannot be used on an empty tuple struct";
                     return syn::parse::Error::new_spanned(item, msg)
                         .to_compile_error()
                         .into();
                 }
-            };
-            let niche_field_name = match niche_field_name {
-                Some(field) => field,
-                None => {
-                    let msg = "#[derive(Niche)] requires a field marked #[niche]";
-                    return syn::parse::Error::new_spanned(item, msg)
-                        .to_compile_error()
-                        .into();
-                }
-            };
+            }
+
+            let where_clause = merge_where_clauses(
+                ty_where_clause,
+                parse_quote! { where #niche_field_type: ::controlled_option::Niche },
+            );
 
             let output = quote! {
-                impl ::controlled_option::Niche for #ty_name {
+                impl #ty_generics ::controlled_option::Niche for #ty_name #ty_generics
+                #where_clause
+                {
                     type Output = ::std::mem::MaybeUninit<Self>;
 
                     #[inline]

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -110,3 +110,28 @@ fn can_option_tuple_structs() {
     assert_eq!(some_repr.0, 75);
     assert_eq!(some_repr.1, 125);
 }
+
+// Same as above, but with type parameters.
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Niche)]
+struct TestGenericStruct<T>(T, #[niche] T);
+
+#[repr(C)]
+#[derive(Debug)]
+struct TestGenericStructRepr<T>(T, T);
+
+#[test]
+fn can_option_generic_structs() {
+    let none = ControlledOption::<TestGenericStruct<NonZeroU32>>::none();
+    assert!(none.is_none());
+    let none_repr: TestGenericStructRepr<u32> = unsafe { std::mem::transmute(none) };
+    assert_eq!(none_repr.1, 0);
+
+    let value = TestGenericStruct(NonZeroU32::new(75).unwrap(), NonZeroU32::new(125).unwrap());
+    let some = ControlledOption::some(value);
+    assert!(some.is_some());
+    let some_repr: TestGenericStructRepr<u32> = unsafe { std::mem::transmute(some) };
+    assert_eq!(some_repr.0, 75);
+    assert_eq!(some_repr.1, 125);
+}


### PR DESCRIPTION
Our derive macro now works with generic struct types.  We copy over any type parameters and where clauses in the struct definition.  We add an additional where clause that ensures that the type of the struct's niche field implements `Niche`.  (That might involve some of the type parameters; it might not!)